### PR TITLE
Drop AST parsing for Jupytext target in favor of calling task functions directly

### DIFF
--- a/ecoscope_workflows/registry.py
+++ b/ecoscope_workflows/registry.py
@@ -3,13 +3,12 @@ entry points. This design is heavily inspired by the `fsspec` package's `registr
 to which we owe a debt of gratitude.
 """
 
-import ast
 import types
 from dataclasses import dataclass
 from enum import Enum
 from importlib import import_module
 from importlib.metadata import entry_points
-from inspect import getmembers, getsource, ismodule
+from inspect import getmembers, ismodule
 from typing import Annotated, Any, Generator, get_args
 
 import ruamel.yaml
@@ -19,7 +18,6 @@ from pydantic import (
     Field,
     FieldSerializationInfo,
     TypeAdapter,
-    computed_field,
     field_serializer,
 )
 from pydantic.functional_validators import AfterValidator
@@ -210,31 +208,6 @@ class KnownTask(BaseModel):
         ):
             params += line
         return params
-
-    @property
-    def _ast_parsed_function_def(self) -> ast.FunctionDef:
-        source = getsource(self.task)
-        module = ast.parse(source)
-        function_def = module.body[0]
-        assert isinstance(function_def, ast.FunctionDef)
-        return function_def
-
-    @computed_field
-    def source_body(self) -> str:
-        return "\n".join(
-            ast.unparse(stmt)
-            for stmt in self._ast_parsed_function_def.body
-            if not isinstance(stmt, ast.Return)
-        )
-
-    @computed_field
-    def source_return(self) -> str:
-        return_stmt = [
-            stmt
-            for stmt in self._ast_parsed_function_def.body
-            if isinstance(stmt, ast.Return)
-        ][0]
-        return ast.unparse(return_stmt).replace("return ", "")
 
 
 _known_tasks = collect_task_entries()  # internal, mutable

--- a/ecoscope_workflows/registry.py
+++ b/ecoscope_workflows/registry.py
@@ -201,12 +201,13 @@ class KnownTask(BaseModel):
         return yaml_str
 
     def parameters_notebook(self, omit_args: list[str] | None = None) -> str:
-        params = ""
+        params = "dict(\n"
         for line in self._iter_parameters_annotation(
-            fmt="{arg} = ...\n",
+            fmt="    {arg}=...,\n",
             omit_args=omit_args,
         ):
             params += line
+        params += ")"
         return params
 
 

--- a/ecoscope_workflows/templates/jupytext.jinja2
+++ b/ecoscope_workflows/templates/jupytext.jinja2
@@ -4,32 +4,36 @@
 # # {{ name.title().replace("_", " ") }}
 # TODO: top level description
 
-{% for t in tasks -%}
+# %% [markdown]
+# ## Imports
 
+{% for t in tasks -%}
+{{ t.known_task.importable_reference.statement }}
+{% if loop.last %}
+{% endif -%}
+{% endfor -%}
+
+
+{% for t in tasks -%}
 # %% [markdown]
 # ## {{ t.known_task.importable_reference.function.title().replace("_", " ") }}
-
-{%- if t.arg_dependencies %}
-# %%
-# dependencies assignments
-
-{% for arg in t.arg_dependencies %}{{ arg }} = {{ t.arg_dependencies[arg] }}{% endfor %}
-{% endif %}
 
 # %%
 # parameters
 
-{{ t.known_task.importable_reference.params_notebook }}
+{{ t.known_task.importable_reference.function }}_params = {{ t.known_task.importable_reference.params_notebook }}
 
 # %%
-# the code for {{ t.known_task.importable_reference.function.title().replace("_", " ") }}
+# call the task
 
-{{ t.known_task.source_body }}
+{{ t.known_task.importable_reference.function }}_return = {{ t.known_task.importable_reference.function }}(
+{%- if t.arg_dependencies %}
+    {% for arg in t.arg_dependencies %}{{ arg }}={{ t.arg_dependencies[arg] }},{% endfor %}
+    **{{ t.known_task.importable_reference.function }}_params,
+)
+{% else %}**{{ t.known_task.importable_reference.function }}_params,
+)
 
-# %%
-# return value from this section
-
-{{ t.known_task.importable_reference.function }}_return = {{ t.known_task.source_return }}
-
+{% endif -%}
 
 {% endfor %}

--- a/examples/dags/patrol_workflow_dag.jupytext.py
+++ b/examples/dags/patrol_workflow_dag.jupytext.py
@@ -5,185 +5,115 @@
 # TODO: top level description
 
 # %% [markdown]
+# ## Imports
+
+from ecoscope_workflows.tasks.io import get_patrol_observations
+from ecoscope_workflows.tasks.preprocessing import process_relocations
+from ecoscope_workflows.tasks.preprocessing import relocations_to_trajectory
+from ecoscope_workflows.tasks.results import draw_ecomap
+from ecoscope_workflows.tasks.io import persist_text
+
+# %% [markdown]
 # ## Get Patrol Observations
 
 # %%
 # parameters
 
-client = ...
-since = ...
-until = ...
-patrol_type = ...
-status = ...
-include_patrol_details = ...
-
-
-# %%
-# the code for Get Patrol Observations
-
-"Get observations for a patrol type from EarthRanger."
-
-# %%
-# return value from this section
-
-get_patrol_observations_return = client.get_patrol_observations_with_patrol_filter(
-    since=since,
-    until=until,
-    patrol_type=patrol_type,
-    status=status,
-    include_patrol_details=include_patrol_details,
+get_patrol_observations_params = dict(
+    client=...,
+    since=...,
+    until=...,
+    patrol_type=...,
+    status=...,
+    include_patrol_details=...,
 )
 
+# %%
+# call the task
+
+get_patrol_observations_return = get_patrol_observations(
+    **get_patrol_observations_params,
+)
 
 # %% [markdown]
 # ## Process Relocations
-# %%
-# dependencies assignments
-
-observations = get_patrol_observations_return
-
 
 # %%
 # parameters
 
-filter_point_coords = ...
-relocs_columns = ...
-
-
-# %%
-# the code for Process Relocations
-
-from ecoscope.base import RelocsCoordinateFilter, Relocations
-
-relocs = Relocations(observations)
-relocs.apply_reloc_filter(
-    RelocsCoordinateFilter(filter_point_coords=filter_point_coords), inplace=True
+process_relocations_params = dict(
+    filter_point_coords=...,
+    relocs_columns=...,
 )
-relocs.remove_filtered(inplace=True)
-relocs = relocs[relocs_columns]
-relocs.columns = [i.replace("extra__", "") for i in relocs.columns]
-relocs.columns = [i.replace("subject__", "") for i in relocs.columns]
 
 # %%
-# return value from this section
+# call the task
 
-process_relocations_return = relocs
-
-
+process_relocations_return = process_relocations(
+    observations=get_patrol_observations_return,
+    **process_relocations_params,
+)
 # %% [markdown]
 # ## Relocations To Trajectory
-# %%
-# dependencies assignments
-
-relocations = process_relocations_return
-
 
 # %%
 # parameters
 
-min_length_meters = ...
-max_length_meters = ...
-max_time_secs = ...
-min_time_secs = ...
-max_speed_kmhr = ...
-min_speed_kmhr = ...
-
-
-# %%
-# the code for Relocations To Trajectory
-
-from ecoscope.base import Relocations
-from ecoscope.base import Trajectory, TrajSegFilter
-
-traj = Trajectory.from_relocations(Relocations(relocations))
-traj_seg_filter = TrajSegFilter(
-    min_length_meters=min_length_meters,
-    max_length_meters=max_length_meters,
-    min_time_secs=min_time_secs,
-    max_time_secs=max_time_secs,
-    min_speed_kmhr=min_speed_kmhr,
-    max_speed_kmhr=max_speed_kmhr,
+relocations_to_trajectory_params = dict(
+    min_length_meters=...,
+    max_length_meters=...,
+    max_time_secs=...,
+    min_time_secs=...,
+    max_speed_kmhr=...,
+    min_speed_kmhr=...,
 )
-traj.apply_traj_filter(traj_seg_filter, inplace=True)
-traj.remove_filtered(inplace=True)
 
 # %%
-# return value from this section
+# call the task
 
-relocations_to_trajectory_return = traj
-
-
+relocations_to_trajectory_return = relocations_to_trajectory(
+    relocations=process_relocations_return,
+    **relocations_to_trajectory_params,
+)
 # %% [markdown]
 # ## Draw Ecomap
-# %%
-# dependencies assignments
-
-geodataframe = relocations_to_trajectory_return
-
 
 # %%
 # parameters
 
-data_type = ...
-style_kws = ...
-tile_layer = ...
-static = ...
-title = ...
-title_kws = ...
-scale_kws = ...
-north_arrow_kws = ...
-
-
-# %%
-# the code for Draw Ecomap
-
-'\n    Creates a map based on the provided layer definitions and configuration.\n\n    Args:\n    geodataframe (geopandas.GeoDataFrame): The geodataframe to visualize.\n    data_type (str): The type of visualization, "Scatterplot", "Path" or "Polygon".\n    style_kws (dict): Style arguments for the data visualization.\n    tile_layer (str): A named tile layer, ie OpenStreetMap.\n    static (bool): Set to true to disable map pan/zoom.\n    title (str): The map title.\n    title_kws (dict): Additional arguments for configuring the Title.\n    scale_kws (dict): Additional arguments for configuring the Scale Bar.\n    north_arrow_kws (dict): Additional arguments for configuring the North Arrow.\n\n    Returns:\n    str: A static HTML representation of the map.\n    '
-from ecoscope.mapping import EcoMap
-
-m = EcoMap(static=static, default_widgets=False)
-if title:
-    m.add_title(title, **title_kws)
-m.add_scale_bar(**scale_kws)
-m.add_north_arrow(**north_arrow_kws)
-if tile_layer:
-    m.add_layer(EcoMap.get_named_tile_layer(tile_layer))
-match data_type:
-    case "Scatterplot":
-        m.add_scatterplot_layer(geodataframe, **style_kws)
-    case "Path":
-        m.add_path_layer(geodataframe, **style_kws)
-    case "Polygon":
-        m.add_polygon_layer(geodataframe, **style_kws)
-m.zoom_to_bounds(m.layers)
+draw_ecomap_params = dict(
+    data_type=...,
+    style_kws=...,
+    tile_layer=...,
+    static=...,
+    title=...,
+    title_kws=...,
+    scale_kws=...,
+    north_arrow_kws=...,
+)
 
 # %%
-# return value from this section
+# call the task
 
-draw_ecomap_return = m.to_html()
-
-
+draw_ecomap_return = draw_ecomap(
+    geodataframe=relocations_to_trajectory_return,
+    **draw_ecomap_params,
+)
 # %% [markdown]
 # ## Persist Text
-# %%
-# dependencies assignments
-
-text = draw_ecomap_return
-
 
 # %%
 # parameters
 
-root_path = ...
-filename = ...
-
-
-# %%
-# the code for Persist Text
-
-"Persist text to a file or cloud storage object."
-from ecoscope_workflows.serde import _persist_text
+persist_text_params = dict(
+    root_path=...,
+    filename=...,
+)
 
 # %%
-# return value from this section
+# call the task
 
-persist_text_return = _persist_text(text, root_path, filename)
+persist_text_return = persist_text(
+    text=draw_ecomap_return,
+    **persist_text_params,
+)

--- a/examples/dags/time_density_dag.jupytext.py
+++ b/examples/dags/time_density_dag.jupytext.py
@@ -5,234 +5,138 @@
 # TODO: top level description
 
 # %% [markdown]
+# ## Imports
+
+from ecoscope_workflows.tasks.io import get_subjectgroup_observations
+from ecoscope_workflows.tasks.preprocessing import process_relocations
+from ecoscope_workflows.tasks.preprocessing import relocations_to_trajectory
+from ecoscope_workflows.tasks.analysis import calculate_time_density
+from ecoscope_workflows.tasks.results import draw_ecomap
+from ecoscope_workflows.tasks.io import persist_text
+
+# %% [markdown]
 # ## Get Subjectgroup Observations
 
 # %%
 # parameters
 
-client = ...
-subject_group_name = ...
-include_inactive = ...
-since = ...
-until = ...
-
-
-# %%
-# the code for Get Subjectgroup Observations
-
-"Get observations for a subject group from EarthRanger."
-
-# %%
-# return value from this section
-
-get_subjectgroup_observations_return = client.get_subjectgroup_observations(
-    subject_group_name=subject_group_name,
-    include_subject_details=True,
-    include_inactive=include_inactive,
-    since=since,
-    until=until,
+get_subjectgroup_observations_params = dict(
+    client=...,
+    subject_group_name=...,
+    include_inactive=...,
+    since=...,
+    until=...,
 )
 
+# %%
+# call the task
+
+get_subjectgroup_observations_return = get_subjectgroup_observations(
+    **get_subjectgroup_observations_params,
+)
 
 # %% [markdown]
 # ## Process Relocations
-# %%
-# dependencies assignments
-
-observations = get_subjectgroup_observations_return
-
 
 # %%
 # parameters
 
-filter_point_coords = ...
-relocs_columns = ...
-
-
-# %%
-# the code for Process Relocations
-
-from ecoscope.base import RelocsCoordinateFilter, Relocations
-
-relocs = Relocations(observations)
-relocs.apply_reloc_filter(
-    RelocsCoordinateFilter(filter_point_coords=filter_point_coords), inplace=True
+process_relocations_params = dict(
+    filter_point_coords=...,
+    relocs_columns=...,
 )
-relocs.remove_filtered(inplace=True)
-relocs = relocs[relocs_columns]
-relocs.columns = [i.replace("extra__", "") for i in relocs.columns]
-relocs.columns = [i.replace("subject__", "") for i in relocs.columns]
 
 # %%
-# return value from this section
+# call the task
 
-process_relocations_return = relocs
-
-
+process_relocations_return = process_relocations(
+    observations=get_subjectgroup_observations_return,
+    **process_relocations_params,
+)
 # %% [markdown]
 # ## Relocations To Trajectory
-# %%
-# dependencies assignments
-
-relocations = process_relocations_return
-
 
 # %%
 # parameters
 
-min_length_meters = ...
-max_length_meters = ...
-max_time_secs = ...
-min_time_secs = ...
-max_speed_kmhr = ...
-min_speed_kmhr = ...
-
-
-# %%
-# the code for Relocations To Trajectory
-
-from ecoscope.base import Relocations
-from ecoscope.base import Trajectory, TrajSegFilter
-
-traj = Trajectory.from_relocations(Relocations(relocations))
-traj_seg_filter = TrajSegFilter(
-    min_length_meters=min_length_meters,
-    max_length_meters=max_length_meters,
-    min_time_secs=min_time_secs,
-    max_time_secs=max_time_secs,
-    min_speed_kmhr=min_speed_kmhr,
-    max_speed_kmhr=max_speed_kmhr,
+relocations_to_trajectory_params = dict(
+    min_length_meters=...,
+    max_length_meters=...,
+    max_time_secs=...,
+    min_time_secs=...,
+    max_speed_kmhr=...,
+    min_speed_kmhr=...,
 )
-traj.apply_traj_filter(traj_seg_filter, inplace=True)
-traj.remove_filtered(inplace=True)
 
 # %%
-# return value from this section
+# call the task
 
-relocations_to_trajectory_return = traj
-
-
+relocations_to_trajectory_return = relocations_to_trajectory(
+    relocations=process_relocations_return,
+    **relocations_to_trajectory_params,
+)
 # %% [markdown]
 # ## Calculate Time Density
-# %%
-# dependencies assignments
-
-trajectory_gdf = relocations_to_trajectory_return
-
 
 # %%
 # parameters
 
-pixel_size = ...
-crs = ...
-nodata_value = ...
-band_count = ...
-max_speed_factor = ...
-expansion_factor = ...
-percentiles = ...
-
+calculate_time_density_params = dict(
+    pixel_size=...,
+    crs=...,
+    nodata_value=...,
+    band_count=...,
+    max_speed_factor=...,
+    expansion_factor=...,
+    percentiles=...,
+)
 
 # %%
-# the code for Calculate Time Density
+# call the task
 
-import tempfile
-from ecoscope.analysis.percentile import get_percentile_area
-from ecoscope.analysis.UD import calculate_etd_range
-from ecoscope.io.raster import RasterProfile
-
-raster_profile = RasterProfile(
-    pixel_size=pixel_size, crs=crs, nodata_value=nodata_value, band_count=band_count
+calculate_time_density_return = calculate_time_density(
+    trajectory_gdf=relocations_to_trajectory_return,
+    **calculate_time_density_params,
 )
-trajectory_gdf.sort_values("segment_start", inplace=True)
-tmp_tif_path = tempfile.NamedTemporaryFile(suffix=".tif")
-calculate_etd_range(
-    trajectory_gdf=trajectory_gdf,
-    output_path=tmp_tif_path,
-    max_speed_kmhr=max_speed_factor * trajectory_gdf["speed_kmhr"].max(),
-    raster_profile=raster_profile,
-    expansion_factor=expansion_factor,
-)
-result = get_percentile_area(percentile_levels=percentiles, raster_path=tmp_tif_path)
-result.drop(columns="subject_id", inplace=True)
-result["area_sqkm"] = result.area / 1000000.0
-
-# %%
-# return value from this section
-
-calculate_time_density_return = result
-
-
 # %% [markdown]
 # ## Draw Ecomap
-# %%
-# dependencies assignments
-
-geodataframe = calculate_time_density_return
-
 
 # %%
 # parameters
 
-data_type = ...
-style_kws = ...
-tile_layer = ...
-static = ...
-title = ...
-title_kws = ...
-scale_kws = ...
-north_arrow_kws = ...
-
-
-# %%
-# the code for Draw Ecomap
-
-'\n    Creates a map based on the provided layer definitions and configuration.\n\n    Args:\n    geodataframe (geopandas.GeoDataFrame): The geodataframe to visualize.\n    data_type (str): The type of visualization, "Scatterplot", "Path" or "Polygon".\n    style_kws (dict): Style arguments for the data visualization.\n    tile_layer (str): A named tile layer, ie OpenStreetMap.\n    static (bool): Set to true to disable map pan/zoom.\n    title (str): The map title.\n    title_kws (dict): Additional arguments for configuring the Title.\n    scale_kws (dict): Additional arguments for configuring the Scale Bar.\n    north_arrow_kws (dict): Additional arguments for configuring the North Arrow.\n\n    Returns:\n    str: A static HTML representation of the map.\n    '
-from ecoscope.mapping import EcoMap
-
-m = EcoMap(static=static, default_widgets=False)
-if title:
-    m.add_title(title, **title_kws)
-m.add_scale_bar(**scale_kws)
-m.add_north_arrow(**north_arrow_kws)
-if tile_layer:
-    m.add_layer(EcoMap.get_named_tile_layer(tile_layer))
-match data_type:
-    case "Scatterplot":
-        m.add_scatterplot_layer(geodataframe, **style_kws)
-    case "Path":
-        m.add_path_layer(geodataframe, **style_kws)
-    case "Polygon":
-        m.add_polygon_layer(geodataframe, **style_kws)
-m.zoom_to_bounds(m.layers)
+draw_ecomap_params = dict(
+    data_type=...,
+    style_kws=...,
+    tile_layer=...,
+    static=...,
+    title=...,
+    title_kws=...,
+    scale_kws=...,
+    north_arrow_kws=...,
+)
 
 # %%
-# return value from this section
+# call the task
 
-draw_ecomap_return = m.to_html()
-
-
+draw_ecomap_return = draw_ecomap(
+    geodataframe=calculate_time_density_return,
+    **draw_ecomap_params,
+)
 # %% [markdown]
 # ## Persist Text
-# %%
-# dependencies assignments
-
-text = draw_ecomap_return
-
 
 # %%
 # parameters
 
-root_path = ...
-filename = ...
-
-
-# %%
-# the code for Persist Text
-
-"Persist text to a file or cloud storage object."
-from ecoscope_workflows.serde import _persist_text
+persist_text_params = dict(
+    root_path=...,
+    filename=...,
+)
 
 # %%
-# return value from this section
+# call the task
 
-persist_text_return = _persist_text(text, root_path, filename)
+persist_text_return = persist_text(
+    text=draw_ecomap_return,
+    **persist_text_params,
+)


### PR DESCRIPTION
Closes #95

As detailed in #95, this unblocks #91 by allowing us to avoid some gnarly workarounds that were becoming necessary there _solely_ for the purpose of accommodating AST parsing as it was implemented for Jupytext compilation.

Again, as discussed in #95, if a central goal of this package was to provide AST parsing, then we could iterate on that feature some more. As it stands, however, that was more of a (frankly) unconsidered experimental idea, that is not tied to our core objectives, and is now becoming a major burden to support.

Importantly, please note that this PR _**does not**_ remove the Jupytext (and thereby Jupyter) compilation target. We still have that! Instead, it just (drastically) simplifies the nature of the code put into that target, bringing it into closer alignment with the code used in the sequential script.

Arguably, this is actually a big win for maintainability, since it reduced divergence in our compilation targets, making them much more similar to one-another, which I actually find that I like aesthetically and from a clarity standpoint (apart from the fact that it is also dramatically easier to maintain).