### PR TITLE
Task: `add_temporal_index`

### DIFF
--- a/ecoscope_workflows/tasks/transformation/__init__.py
+++ b/ecoscope_workflows/tasks/transformation/__init__.py
@@ -1,8 +1,10 @@
 from ._exploding import explode
 from ._filtering import apply_reloc_coord_filter
+from ._indexing import add_temporal_index
 from ._mapping import color_map, map_columns, map_values
 
 __all__ = [
+    "add_temporal_index",
     "map_columns",
     "color_map",
     "map_values",

--- a/ecoscope_workflows/tasks/transformation/_indexing.py
+++ b/ecoscope_workflows/tasks/transformation/_indexing.py
@@ -1,0 +1,81 @@
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from ecoscope_workflows.annotations import AnyDataFrame
+from ecoscope_workflows.decorators import task
+
+
+# TODO: Leverage this information to generate more readable documentation
+# for the `directive` parameter of `add_temporal_index` task. For now, this
+# is not used anywhere, but leaving it here for future reference.
+strftime_directives = {
+    "%a": "Locale's abbreviated weekday name.",
+    "%A": "Locale's full weekday name.",
+    "%b": "Locale's abbreviated month name.",
+    "%B": "Locale's full month name.",
+    "%c": "Locale's appropriate date and time representation.",
+    "%d": "Day of the month as a decimal number [01,31].",
+    "%f": "Microseconds as a decimal number [000000,999999].",
+    "%H": "Hour (24-hour clock) as a decimal number [00,23].",
+    "%I": "Hour (12-hour clock) as a decimal number [01,12].",
+    "%j": "Day of the year as a decimal number [001,366].",
+    "%m": "Month as a decimal number [01,12].",
+    "%M": "Minute as a decimal number [00,59].",
+    "%p": "Locale's equivalent of either AM or PM.",
+    "%S": "Second as a decimal number [00,61].",
+    "%U": "Week number of the year (Sunday as the first day of the week) as a decimal number [00,53].",
+    "%w": "Weekday as a decimal number [0(Sunday),6].",
+    "%W": "Week number of the year (Monday as the first day of the week) as a decimal number [00,53].",
+    "%x": "Locale's appropriate date representation.",
+    "%X": "Locale's appropriate time representation.",
+    "%y": "Year without century as a decimal number [00,99].",
+    "%Y": "Year with century as a decimal number.",
+    "%z": "Time zone offset indicating a positive or negative time difference from UTC/GMT of the form +HHMM or -HHMM.",
+    "%%": "A literal '%' character.",
+}
+
+Directives = Literal[
+    "%a",
+    "%A",
+    "%b",
+    "%B",
+    "%c",
+    "%d",
+    "%f",
+    "%H",
+    "%I",
+    "%j",
+    "%m",
+    "%M",
+    "%p",
+    "%S",
+    "%U",
+    "%w",
+    "%W",
+    "%x",
+    "%X",
+    "%y",
+    "%Y",
+    "%z",
+    "%%",
+]
+
+
+@task
+def add_temporal_index(
+    df: Annotated[
+        AnyDataFrame, Field(description="The dataframe to add the temporal index to.")
+    ],
+    index_name: Annotated[
+        str, Field(description="A name for the new index which will be added.")
+    ],
+    time_col: Annotated[
+        str, Field(description="Name of existing column containing time data.")
+    ],
+    directive: Annotated[
+        Directives, Field(description="A directive for formatting the time data.")
+    ],
+):
+    df[index_name] = df[time_col].dt.strftime(directive)
+    return df.set_index(index_name, append=True)

--- a/tests/tasks/test_indexing.py
+++ b/tests/tasks/test_indexing.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from ecoscope_workflows.tasks.transformation import add_temporal_index
+
+
+def test_add_temporal_index():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                ["2022-01-01", "2022-01-02", "2022-02-01", "2022-02-02"]
+            ),
+            "value": [1, 2, 3, 4],
+        }
+    )
+    assert list(df.index.values) == [0, 1, 2, 3]
+
+    with_month_index = add_temporal_index(
+        df,
+        index_name="month",
+        time_col="timestamp",
+        directive="%B",
+    )
+    assert list(with_month_index.index.values) == [
+        (0, "January"),
+        (1, "January"),
+        (2, "February"),
+        (3, "February"),
+    ]


### PR DESCRIPTION
Closes #169 

Reimplements ecoscope core logic linked in #169 because it's just a few lines of boilerplate pandas, so I figure it's not worth depending on upstream for that.

Merging to #168 to unblock that PR.

cc @Yun-Wu and @walljcg for visibility (Thanks for understanding the moving fast w/out review, so I can finish e2e patrols. Happy to field feedback via follow-up issues!)