### PR TITLE
Add grouped single value widgets to dashboard

### DIFF
--- a/ecoscope_workflows/tasks/analysis/__init__.py
+++ b/ecoscope_workflows/tasks/analysis/__init__.py
@@ -1,4 +1,5 @@
 from ._aggregation import (
+    apply_arithmetic_operation,
     dataframe_column_mean,
     dataframe_column_nunique,
     dataframe_column_sum,
@@ -8,6 +9,7 @@ from ._time_density import TimeDensityReturnGDFSchema, calculate_time_density
 
 __all__ = [
     "TimeDensityReturnGDFSchema",
+    "apply_arithmetic_operation",
     "dataframe_column_mean",
     "dataframe_column_nunique",
     "dataframe_column_sum",

--- a/ecoscope_workflows/tasks/analysis/__init__.py
+++ b/ecoscope_workflows/tasks/analysis/__init__.py
@@ -1,6 +1,8 @@
 from ._aggregation import (
     apply_arithmetic_operation,
     dataframe_column_mean,
+    dataframe_column_max,
+    dataframe_column_min,
     dataframe_column_nunique,
     dataframe_column_sum,
     dataframe_count,
@@ -11,6 +13,8 @@ __all__ = [
     "TimeDensityReturnGDFSchema",
     "apply_arithmetic_operation",
     "dataframe_column_mean",
+    "dataframe_column_max",
+    "dataframe_column_min",
     "dataframe_column_nunique",
     "dataframe_column_sum",
     "dataframe_count",

--- a/ecoscope_workflows/tasks/analysis/__init__.py
+++ b/ecoscope_workflows/tasks/analysis/__init__.py
@@ -1,8 +1,16 @@
-from ._aggregation import aggregate
+from ._aggregation import (
+    dataframe_column_mean,
+    dataframe_column_nunique,
+    dataframe_column_sum,
+    dataframe_count,
+)
 from ._time_density import TimeDensityReturnGDFSchema, calculate_time_density
 
 __all__ = [
     "TimeDensityReturnGDFSchema",
+    "dataframe_column_mean",
+    "dataframe_column_nunique",
+    "dataframe_column_sum",
+    "dataframe_count",
     "calculate_time_density",
-    "aggregate",
 ]

--- a/ecoscope_workflows/tasks/analysis/_aggregation.py
+++ b/ecoscope_workflows/tasks/analysis/_aggregation.py
@@ -1,4 +1,5 @@
-from typing import Annotated
+from operator import add, sub, mul, truediv, floordiv, mod, pow
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -38,3 +39,31 @@ def dataframe_column_nunique(
     column_name: ColumnName,
 ) -> Annotated[int, Field(description="The number of unique values in the column")]:
     return df[column_name].nunique()
+
+
+operations = {
+    "add": add,
+    "subtract": sub,
+    "multiply": mul,
+    "divide": truediv,
+    "floor_divide": floordiv,
+    "modulo": mod,
+    "power": pow,
+}
+
+Operations = Literal[
+    "add", "subtract", "multiply", "divide", "floor_divide", "modulo", "power"
+]
+
+
+@task
+def apply_arithmetic_operation(
+    a: Annotated[float | int, Field(description="The first number")],
+    b: Annotated[float | int, Field(description="The second number")],
+    operation: Annotated[
+        Operations, Field(description="The arithmetic operation to apply")
+    ],
+) -> Annotated[
+    float | int, Field(description="The result of the arithmetic operation")
+]:
+    return operations[operation](a, b)

--- a/ecoscope_workflows/tasks/analysis/_aggregation.py
+++ b/ecoscope_workflows/tasks/analysis/_aggregation.py
@@ -22,7 +22,7 @@ def aggregate(
             return df[column_name].mean()
         case "SUM":
             return df[column_name].sum()
-        # case "NUNIQUE":
-        #     ...
+        case "NUNIQUE":
+            return df[column_name].nunique()
         case _:
             raise ValueError(f"Unknown aggregation function: {func_name}")

--- a/ecoscope_workflows/tasks/analysis/_aggregation.py
+++ b/ecoscope_workflows/tasks/analysis/_aggregation.py
@@ -1,26 +1,28 @@
 from typing import Annotated, Literal
 
-import pandas as pd
 from pydantic import Field
 
-from ecoscope_workflows.annotations import DataFrame, JsonSerializableDataFrameModel
+from ecoscope_workflows.annotations import AnyDataFrame
 from ecoscope_workflows.decorators import task
 
 
 @task
 def aggregate(
-    df: DataFrame[JsonSerializableDataFrameModel],
+    df: AnyDataFrame,
     column_name: Annotated[str, Field(description="Column to aggregate")],
     func_name: Annotated[
-        Literal["count", "mean", "sum"], Field(description="The method of aggregation")
+        Literal["count", "mean", "sum", "nunique"],
+        Field(description="The method of aggregation"),
     ],
-) -> DataFrame[JsonSerializableDataFrameModel]:
+) -> Annotated[int | float, Field(description="The result of the aggregation")]:
     match func_name.upper():
         case "COUNT":
-            return pd.Series({f"{column_name}_count": len(df)})
+            return len(df)
         case "MEAN":
-            return pd.Series({f"{column_name}_mean": df[column_name].mean()})
+            return df[column_name].mean()
         case "SUM":
-            return pd.Series({f"{column_name}_sum": df[column_name].sum()})
+            return df[column_name].sum()
+        # case "NUNIQUE":
+        #     ...
         case _:
             raise ValueError(f"Unknown aggregation function: {func_name}")

--- a/ecoscope_workflows/tasks/analysis/_aggregation.py
+++ b/ecoscope_workflows/tasks/analysis/_aggregation.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal
+from typing import Annotated
 
 from pydantic import Field
 
@@ -6,23 +6,35 @@ from ecoscope_workflows.annotations import AnyDataFrame
 from ecoscope_workflows.decorators import task
 
 
+ColumnName = Annotated[str, Field(description="Column to aggregate")]
+
+
 @task
-def aggregate(
+def dataframe_count(
     df: AnyDataFrame,
-    column_name: Annotated[str, Field(description="Column to aggregate")],
-    func_name: Annotated[
-        Literal["count", "mean", "sum", "nunique"],
-        Field(description="The method of aggregation"),
-    ],
-) -> Annotated[int | float, Field(description="The result of the aggregation")]:
-    match func_name.upper():
-        case "COUNT":
-            return len(df)
-        case "MEAN":
-            return df[column_name].mean()
-        case "SUM":
-            return df[column_name].sum()
-        case "NUNIQUE":
-            return df[column_name].nunique()
-        case _:
-            raise ValueError(f"Unknown aggregation function: {func_name}")
+) -> Annotated[int, Field(description="The number of rows in the DataFrame")]:
+    return len(df)
+
+
+@task
+def dataframe_column_mean(
+    df: AnyDataFrame,
+    column_name: ColumnName,
+) -> Annotated[float, Field(description="The mean of the column")]:
+    return df[column_name].mean()
+
+
+@task
+def dataframe_column_sum(
+    df: AnyDataFrame,
+    column_name: ColumnName,
+) -> Annotated[float, Field(description="The sum of the column")]:
+    return df[column_name].sum()
+
+
+@task
+def dataframe_column_nunique(
+    df: AnyDataFrame,
+    column_name: ColumnName,
+) -> Annotated[int, Field(description="The number of unique values in the column")]:
+    return df[column_name].nunique()

--- a/ecoscope_workflows/tasks/analysis/_aggregation.py
+++ b/ecoscope_workflows/tasks/analysis/_aggregation.py
@@ -34,6 +34,22 @@ def dataframe_column_sum(
 
 
 @task
+def dataframe_column_max(
+    df: AnyDataFrame,
+    column_name: ColumnName,
+) -> Annotated[float, Field(description="The max of the column")]:
+    return df[column_name].max()
+
+
+@task
+def dataframe_column_min(
+    df: AnyDataFrame,
+    column_name: ColumnName,
+) -> Annotated[float, Field(description="The min of the column")]:
+    return df[column_name].min()
+
+
+@task
 def dataframe_column_nunique(
     df: AnyDataFrame,
     column_name: ColumnName,

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -104,6 +104,27 @@ workflow:
     partial:
       widgets: ${{ workflow.traj_pe_map_widgets_single_views.return }}
 
+  # Grouped single value widgets
+  - name: Calculate Total Patrols Per Group
+    id: total_patrols
+    task: aggregate
+    partial:
+      func_name: "nunique"
+    mapvalues:
+      argnames: df
+      argvalues: ${{ workflow.split_patrol_traj_groups.return }}
+  - name: Create Single Value Widgets for Total Patrols Per Group
+    id: total_patrols_grouped_sv_widgets
+    task: create_single_value_widget_single_view
+    map:
+      argnames: [view, data]
+      argvalues: ${{ workflow.total_patrols.return }}
+  - name: Merge per group Total Patrols SV widgets into one Grouped Widget
+    id: traj_pe_grouped_map_widget
+    task: merge_widget_views
+    partial:
+      widgets: ${{ workflow.total_patrols_grouped_sv_widgets.return }}
+
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events
     id: patrol_events_bar_chart
@@ -179,4 +200,9 @@ workflow:
         - ${{ workflow.td_map_widget.return }}
         - ${{ workflow.patrol_events_bar_chart_widget.return }}
         - ${{ workflow.patrol_events_pie_chart_widget.return }}
+        - ${{ workflow.total_patrols_grouped_sv_widget.return }}
+        # - ${{ workflow.total_time_grouped_sv_widget.return }}
+        # - ${{ workflow.total_distance_grouped_sv_widget.return }}
+        # - ${{ workflow.avg_speed_grouped_sv_widget.return }}
+        # - ${{ workflow.max_speed_grouped_sv_widget.return }}
       groupers: ${{ workflow.groupers.return }}

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -141,12 +141,37 @@ workflow:
     task: create_single_value_widget_single_view
     map:
       argnames: [view, data]
-      argvalues: ${{ workflow.total_patrol_time.return }}
+      argvalues: ${{ workflow.total_patrol_time_converted.return }}
   - name: Merge per group Total Patrol Per Group SV widgets
     id: patrol_time_grouped_widget
     task: merge_widget_views
     partial:
       widgets: ${{ workflow.total_patrol_time_sv_widgets.return }}
+
+  # Grouped single value widget (3) - total distance per group
+  - name: Calculate Total Distance Per Group
+    id: total_patrol_dist
+    task: dataframe_column_sum
+    mapvalues:
+      argnames: df
+      argvalues: ${{ workflow.split_patrol_traj_groups.return }}
+  - name: Convert total patrol distance units
+    id: total_patrol_dist_converted
+    task: apply_arithmetic_operation
+    mapvalues:
+      argnames: a
+      argvalues: ${{ workflow.total_patrol_dist.return }}
+  - name: Create Single Value Widgets for Total Distance Per Group
+    id: total_patrol_dist_sv_widgets
+    task: create_single_value_widget_single_view
+    map:
+      argnames: [view, data]
+      argvalues: ${{ workflow.total_patrol_dist_converted.return }}
+  - name: Merge per group Total Patrol Per Group SV widgets
+    id: patrol_dist_grouped_widget
+    task: merge_widget_views
+    partial:
+      widgets: ${{ workflow.total_patrol_dist_sv_widgets.return }}
 
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events
@@ -225,7 +250,7 @@ workflow:
         - ${{ workflow.patrol_events_pie_chart_widget.return }}
         - ${{ workflow.total_patrols_grouped_sv_widget.return }}
         - ${{ workflow.patrol_time_grouped_widget.return }}
-        # - ${{ workflow.total_distance_grouped_sv_widget.return }}
+        - ${{ workflow.patrol_dist_grouped_widget.return }}
         # - ${{ workflow.avg_speed_grouped_sv_widget.return }}
         # - ${{ workflow.max_speed_grouped_sv_widget.return }}
       groupers: ${{ workflow.groupers.return }}

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -142,7 +142,7 @@ workflow:
     map:
       argnames: [view, data]
       argvalues: ${{ workflow.total_patrol_time_converted.return }}
-  - name: Merge per group Total Patrol Per Group SV widgets
+  - name: Merge per group Total Patrol Time SV widgets
     id: patrol_time_grouped_widget
     task: merge_widget_views
     partial:
@@ -167,11 +167,30 @@ workflow:
     map:
       argnames: [view, data]
       argvalues: ${{ workflow.total_patrol_dist_converted.return }}
-  - name: Merge per group Total Patrol Per Group SV widgets
+  - name: Merge per group Total Patrol Distance SV widgets
     id: patrol_dist_grouped_widget
     task: merge_widget_views
     partial:
       widgets: ${{ workflow.total_patrol_dist_sv_widgets.return }}
+
+  # Grouped single value widget (4) - average speed per group
+  - name: Calculate Average Speed Per Group
+    id: avg_speed
+    task: dataframe_column_mean
+    mapvalues:
+      argnames: df
+      argvalues: ${{ workflow.split_patrol_traj_groups.return }}
+  - name: Create Single Value Widgets for Avg Speed Per Group
+    id: avg_speed_sv_widgets
+    task: create_single_value_widget_single_view
+    map:
+      argnames: [view, data]
+      argvalues: ${{ workflow.avg_speed.return }}
+  - name: Merge per group Avg Speed SV widgets
+    id: avg_speed_grouped_widget
+    task: merge_widget_views
+    partial:
+      widgets: ${{ workflow.avg_speed_sv_widgets.return }}
 
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events
@@ -251,6 +270,6 @@ workflow:
         - ${{ workflow.total_patrols_grouped_sv_widget.return }}
         - ${{ workflow.patrol_time_grouped_widget.return }}
         - ${{ workflow.patrol_dist_grouped_widget.return }}
-        # - ${{ workflow.avg_speed_grouped_sv_widget.return }}
+        - ${{ workflow.avg_speed_grouped_widget.return }}
         # - ${{ workflow.max_speed_grouped_sv_widget.return }}
       groupers: ${{ workflow.groupers.return }}

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -107,23 +107,21 @@ workflow:
   # Grouped single value widgets
   - name: Calculate Total Patrols Per Group
     id: total_patrols
-    task: aggregate
-    partial:
-      func_name: "nunique"
+    task: dataframe_column_nunique
     mapvalues:
       argnames: df
       argvalues: ${{ workflow.split_patrol_traj_groups.return }}
   - name: Create Single Value Widgets for Total Patrols Per Group
-    id: total_patrols_grouped_sv_widgets
+    id: total_patrols_sv_widgets
     task: create_single_value_widget_single_view
     map:
       argnames: [view, data]
       argvalues: ${{ workflow.total_patrols.return }}
   - name: Merge per group Total Patrols SV widgets into one Grouped Widget
-    id: traj_pe_grouped_map_widget
+    id: total_patrols_grouped_sv_widget
     task: merge_widget_views
     partial:
-      widgets: ${{ workflow.total_patrols_grouped_sv_widgets.return }}
+      widgets: ${{ workflow.total_patrols_sv_widgets.return }}
 
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -192,6 +192,26 @@ workflow:
     partial:
       widgets: ${{ workflow.avg_speed_sv_widgets.return }}
 
+
+  # Grouped single value widget (4) - max speed per group
+  - name: Calculate Max Speed Per Group
+    id: max_speed
+    task: dataframe_column_max
+    mapvalues:
+      argnames: df
+      argvalues: ${{ workflow.split_patrol_traj_groups.return }}
+  - name: Create Single Value Widgets for Max Speed Per Group
+    id: max_speed_sv_widgets
+    task: create_single_value_widget_single_view
+    map:
+      argnames: [view, data]
+      argvalues: ${{ workflow.max_speed.return }}
+  - name: Merge per group Max Speed SV widgets
+    id: max_speed_grouped_widget
+    task: merge_widget_views
+    partial:
+      widgets: ${{ workflow.max_speed_sv_widgets.return }}
+
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events
     id: patrol_events_bar_chart
@@ -271,5 +291,5 @@ workflow:
         - ${{ workflow.patrol_time_grouped_widget.return }}
         - ${{ workflow.patrol_dist_grouped_widget.return }}
         - ${{ workflow.avg_speed_grouped_widget.return }}
-        # - ${{ workflow.max_speed_grouped_sv_widget.return }}
+        - ${{ workflow.max_speed_grouped_widget.return }}
       groupers: ${{ workflow.groupers.return }}

--- a/examples/compilation-specs/patrol_workflow.yaml
+++ b/examples/compilation-specs/patrol_workflow.yaml
@@ -104,7 +104,7 @@ workflow:
     partial:
       widgets: ${{ workflow.traj_pe_map_widgets_single_views.return }}
 
-  # Grouped single value widgets
+  # Grouped single value widget (1) - total patrols per group
   - name: Calculate Total Patrols Per Group
     id: total_patrols
     task: dataframe_column_nunique
@@ -117,11 +117,36 @@ workflow:
     map:
       argnames: [view, data]
       argvalues: ${{ workflow.total_patrols.return }}
-  - name: Merge per group Total Patrols SV widgets into one Grouped Widget
+  - name: Merge per group Total Patrols SV widgets
     id: total_patrols_grouped_sv_widget
     task: merge_widget_views
     partial:
       widgets: ${{ workflow.total_patrols_sv_widgets.return }}
+
+  # Grouped single value widget (2) - total patrol time per group
+  - name: Calculate Total Patrol Time Per Group
+    id: total_patrol_time
+    task: dataframe_column_sum
+    mapvalues:
+      argnames: df
+      argvalues: ${{ workflow.split_patrol_traj_groups.return }}
+  - name: Convert total patrol time units
+    id: total_patrol_time_converted
+    task: apply_arithmetic_operation
+    mapvalues:
+      argnames: a
+      argvalues: ${{ workflow.total_patrol_time.return }}
+  - name: Create Single Value Widgets for Total Patrol Time Per Group
+    id: total_patrol_time_sv_widgets
+    task: create_single_value_widget_single_view
+    map:
+      argnames: [view, data]
+      argvalues: ${{ workflow.total_patrol_time.return }}
+  - name: Merge per group Total Patrol Per Group SV widgets
+    id: patrol_time_grouped_widget
+    task: merge_widget_views
+    partial:
+      widgets: ${{ workflow.total_patrol_time_sv_widgets.return }}
 
   # patrol events bar chart
   - name: Draw Time Series Bar Chart for Patrols Events
@@ -199,7 +224,7 @@ workflow:
         - ${{ workflow.patrol_events_bar_chart_widget.return }}
         - ${{ workflow.patrol_events_pie_chart_widget.return }}
         - ${{ workflow.total_patrols_grouped_sv_widget.return }}
-        # - ${{ workflow.total_time_grouped_sv_widget.return }}
+        - ${{ workflow.patrol_time_grouped_widget.return }}
         # - ${{ workflow.total_distance_grouped_sv_widget.return }}
         # - ${{ workflow.avg_speed_grouped_sv_widget.return }}
         # - ${{ workflow.max_speed_grouped_sv_widget.return }}

--- a/examples/dags/patrol_workflow_dag.jupytext.py
+++ b/examples/dags/patrol_workflow_dag.jupytext.py
@@ -22,6 +22,12 @@ from ecoscope_workflows.tasks.results import draw_ecomap
 from ecoscope_workflows.tasks.io import persist_text
 from ecoscope_workflows.tasks.results import create_map_widget_single_view
 from ecoscope_workflows.tasks.results import merge_widget_views
+from ecoscope_workflows.tasks.analysis import dataframe_column_nunique
+from ecoscope_workflows.tasks.results import create_single_value_widget_single_view
+from ecoscope_workflows.tasks.analysis import dataframe_column_sum
+from ecoscope_workflows.tasks.analysis import apply_arithmetic_operation
+from ecoscope_workflows.tasks.analysis import dataframe_column_mean
+from ecoscope_workflows.tasks.analysis import dataframe_column_max
 from ecoscope_workflows.tasks.results import draw_time_series_bar_chart
 from ecoscope_workflows.tasks.results import create_plot_widget_single_view
 from ecoscope_workflows.tasks.results import draw_pie_chart
@@ -373,6 +379,321 @@ traj_pe_grouped_map_widget = merge_widget_views.partial(
 
 
 # %% [markdown]
+# ## Calculate Total Patrols Per Group
+
+# %%
+# parameters
+
+total_patrols_params = dict(
+    column_name=...,
+)
+
+# %%
+# call the task
+
+
+total_patrols = dataframe_column_nunique.partial(**total_patrols_params).mapvalues(
+    argnames=["df"], argvalues=split_patrol_traj_groups
+)
+
+
+# %% [markdown]
+# ## Create Single Value Widgets for Total Patrols Per Group
+
+# %%
+# parameters
+
+total_patrols_sv_widgets_params = dict(
+    title=...,
+)
+
+# %%
+# call the task
+
+
+total_patrols_sv_widgets = create_single_value_widget_single_view.partial(
+    **total_patrols_sv_widgets_params
+).map(argnames=["view", "data"], argvalues=total_patrols)
+
+
+# %% [markdown]
+# ## Merge per group Total Patrols SV widgets
+
+# %%
+# parameters
+
+total_patrols_grouped_sv_widget_params = dict()
+
+# %%
+# call the task
+
+
+total_patrols_grouped_sv_widget = merge_widget_views.partial(
+    widgets=total_patrols_sv_widgets
+).call(**total_patrols_grouped_sv_widget_params)
+
+
+# %% [markdown]
+# ## Calculate Total Patrol Time Per Group
+
+# %%
+# parameters
+
+total_patrol_time_params = dict(
+    column_name=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_time = dataframe_column_sum.partial(**total_patrol_time_params).mapvalues(
+    argnames=["df"], argvalues=split_patrol_traj_groups
+)
+
+
+# %% [markdown]
+# ## Convert total patrol time units
+
+# %%
+# parameters
+
+total_patrol_time_converted_params = dict(
+    b=...,
+    operation=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_time_converted = apply_arithmetic_operation.partial(
+    **total_patrol_time_converted_params
+).mapvalues(argnames=["a"], argvalues=total_patrol_time)
+
+
+# %% [markdown]
+# ## Create Single Value Widgets for Total Patrol Time Per Group
+
+# %%
+# parameters
+
+total_patrol_time_sv_widgets_params = dict(
+    title=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_time_sv_widgets = create_single_value_widget_single_view.partial(
+    **total_patrol_time_sv_widgets_params
+).map(argnames=["view", "data"], argvalues=total_patrol_time_converted)
+
+
+# %% [markdown]
+# ## Merge per group Total Patrol Time SV widgets
+
+# %%
+# parameters
+
+patrol_time_grouped_widget_params = dict()
+
+# %%
+# call the task
+
+
+patrol_time_grouped_widget = merge_widget_views.partial(
+    widgets=total_patrol_time_sv_widgets
+).call(**patrol_time_grouped_widget_params)
+
+
+# %% [markdown]
+# ## Calculate Total Distance Per Group
+
+# %%
+# parameters
+
+total_patrol_dist_params = dict(
+    column_name=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_dist = dataframe_column_sum.partial(**total_patrol_dist_params).mapvalues(
+    argnames=["df"], argvalues=split_patrol_traj_groups
+)
+
+
+# %% [markdown]
+# ## Convert total patrol distance units
+
+# %%
+# parameters
+
+total_patrol_dist_converted_params = dict(
+    b=...,
+    operation=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_dist_converted = apply_arithmetic_operation.partial(
+    **total_patrol_dist_converted_params
+).mapvalues(argnames=["a"], argvalues=total_patrol_dist)
+
+
+# %% [markdown]
+# ## Create Single Value Widgets for Total Distance Per Group
+
+# %%
+# parameters
+
+total_patrol_dist_sv_widgets_params = dict(
+    title=...,
+)
+
+# %%
+# call the task
+
+
+total_patrol_dist_sv_widgets = create_single_value_widget_single_view.partial(
+    **total_patrol_dist_sv_widgets_params
+).map(argnames=["view", "data"], argvalues=total_patrol_dist_converted)
+
+
+# %% [markdown]
+# ## Merge per group Total Patrol Distance SV widgets
+
+# %%
+# parameters
+
+patrol_dist_grouped_widget_params = dict()
+
+# %%
+# call the task
+
+
+patrol_dist_grouped_widget = merge_widget_views.partial(
+    widgets=total_patrol_dist_sv_widgets
+).call(**patrol_dist_grouped_widget_params)
+
+
+# %% [markdown]
+# ## Calculate Average Speed Per Group
+
+# %%
+# parameters
+
+avg_speed_params = dict(
+    column_name=...,
+)
+
+# %%
+# call the task
+
+
+avg_speed = dataframe_column_mean.partial(**avg_speed_params).mapvalues(
+    argnames=["df"], argvalues=split_patrol_traj_groups
+)
+
+
+# %% [markdown]
+# ## Create Single Value Widgets for Avg Speed Per Group
+
+# %%
+# parameters
+
+avg_speed_sv_widgets_params = dict(
+    title=...,
+)
+
+# %%
+# call the task
+
+
+avg_speed_sv_widgets = create_single_value_widget_single_view.partial(
+    **avg_speed_sv_widgets_params
+).map(argnames=["view", "data"], argvalues=avg_speed)
+
+
+# %% [markdown]
+# ## Merge per group Avg Speed SV widgets
+
+# %%
+# parameters
+
+avg_speed_grouped_widget_params = dict()
+
+# %%
+# call the task
+
+
+avg_speed_grouped_widget = merge_widget_views.partial(
+    widgets=avg_speed_sv_widgets
+).call(**avg_speed_grouped_widget_params)
+
+
+# %% [markdown]
+# ## Calculate Max Speed Per Group
+
+# %%
+# parameters
+
+max_speed_params = dict(
+    column_name=...,
+)
+
+# %%
+# call the task
+
+
+max_speed = dataframe_column_max.partial(**max_speed_params).mapvalues(
+    argnames=["df"], argvalues=split_patrol_traj_groups
+)
+
+
+# %% [markdown]
+# ## Create Single Value Widgets for Max Speed Per Group
+
+# %%
+# parameters
+
+max_speed_sv_widgets_params = dict(
+    title=...,
+)
+
+# %%
+# call the task
+
+
+max_speed_sv_widgets = create_single_value_widget_single_view.partial(
+    **max_speed_sv_widgets_params
+).map(argnames=["view", "data"], argvalues=max_speed)
+
+
+# %% [markdown]
+# ## Merge per group Max Speed SV widgets
+
+# %%
+# parameters
+
+max_speed_grouped_widget_params = dict()
+
+# %%
+# call the task
+
+
+max_speed_grouped_widget = merge_widget_views.partial(
+    widgets=max_speed_sv_widgets
+).call(**max_speed_grouped_widget_params)
+
+
+# %% [markdown]
 # ## Draw Time Series Bar Chart for Patrols Events
 
 # %%
@@ -621,6 +942,11 @@ patrol_dashboard = gather_dashboard.partial(
         td_map_widget,
         patrol_events_bar_chart_widget,
         patrol_events_pie_chart_widget,
+        total_patrols_grouped_sv_widget,
+        patrol_time_grouped_widget,
+        patrol_dist_grouped_widget,
+        avg_speed_grouped_widget,
+        max_speed_grouped_widget,
     ],
     groupers=groupers,
 ).call(**patrol_dashboard_params)

--- a/examples/dags/patrol_workflow_dag.script_sequential.py
+++ b/examples/dags/patrol_workflow_dag.script_sequential.py
@@ -21,6 +21,7 @@ from ecoscope_workflows.tasks.results import create_single_value_widget_single_v
 from ecoscope_workflows.tasks.analysis import dataframe_column_sum
 from ecoscope_workflows.tasks.analysis import apply_arithmetic_operation
 from ecoscope_workflows.tasks.analysis import dataframe_column_mean
+from ecoscope_workflows.tasks.analysis import dataframe_column_max
 from ecoscope_workflows.tasks.results import draw_time_series_bar_chart
 from ecoscope_workflows.tasks.results import create_plot_widget_single_view
 from ecoscope_workflows.tasks.results import draw_pie_chart
@@ -216,6 +217,24 @@ if __name__ == "__main__":
         .call(**params["avg_speed_grouped_widget"])
     )
 
+    max_speed = (
+        dataframe_column_max.validate()
+        .partial(**params["max_speed"])
+        .mapvalues(argnames=["df"], argvalues=split_patrol_traj_groups)
+    )
+
+    max_speed_sv_widgets = (
+        create_single_value_widget_single_view.validate()
+        .partial(**params["max_speed_sv_widgets"])
+        .map(argnames=["view", "data"], argvalues=max_speed)
+    )
+
+    max_speed_grouped_widget = (
+        merge_widget_views.validate()
+        .partial(widgets=max_speed_sv_widgets)
+        .call(**params["max_speed_grouped_widget"])
+    )
+
     patrol_events_bar_chart = (
         draw_time_series_bar_chart.validate()
         .partial(dataframe=filter_patrol_events)
@@ -300,6 +319,7 @@ if __name__ == "__main__":
                 patrol_time_grouped_widget,
                 patrol_dist_grouped_widget,
                 avg_speed_grouped_widget,
+                max_speed_grouped_widget,
             ],
             groupers=groupers,
         )

--- a/examples/dags/patrol_workflow_dag.script_sequential.py
+++ b/examples/dags/patrol_workflow_dag.script_sequential.py
@@ -20,6 +20,7 @@ from ecoscope_workflows.tasks.analysis import dataframe_column_nunique
 from ecoscope_workflows.tasks.results import create_single_value_widget_single_view
 from ecoscope_workflows.tasks.analysis import dataframe_column_sum
 from ecoscope_workflows.tasks.analysis import apply_arithmetic_operation
+from ecoscope_workflows.tasks.analysis import dataframe_column_mean
 from ecoscope_workflows.tasks.results import draw_time_series_bar_chart
 from ecoscope_workflows.tasks.results import create_plot_widget_single_view
 from ecoscope_workflows.tasks.results import draw_pie_chart
@@ -197,6 +198,24 @@ if __name__ == "__main__":
         .call(**params["patrol_dist_grouped_widget"])
     )
 
+    avg_speed = (
+        dataframe_column_mean.validate()
+        .partial(**params["avg_speed"])
+        .mapvalues(argnames=["df"], argvalues=split_patrol_traj_groups)
+    )
+
+    avg_speed_sv_widgets = (
+        create_single_value_widget_single_view.validate()
+        .partial(**params["avg_speed_sv_widgets"])
+        .map(argnames=["view", "data"], argvalues=avg_speed)
+    )
+
+    avg_speed_grouped_widget = (
+        merge_widget_views.validate()
+        .partial(widgets=avg_speed_sv_widgets)
+        .call(**params["avg_speed_grouped_widget"])
+    )
+
     patrol_events_bar_chart = (
         draw_time_series_bar_chart.validate()
         .partial(dataframe=filter_patrol_events)
@@ -280,6 +299,7 @@ if __name__ == "__main__":
                 total_patrols_grouped_sv_widget,
                 patrol_time_grouped_widget,
                 patrol_dist_grouped_widget,
+                avg_speed_grouped_widget,
             ],
             groupers=groupers,
         )

--- a/examples/dags/patrol_workflow_dag.script_sequential.py
+++ b/examples/dags/patrol_workflow_dag.script_sequential.py
@@ -164,13 +164,37 @@ if __name__ == "__main__":
     total_patrol_time_sv_widgets = (
         create_single_value_widget_single_view.validate()
         .partial(**params["total_patrol_time_sv_widgets"])
-        .map(argnames=["view", "data"], argvalues=total_patrol_time)
+        .map(argnames=["view", "data"], argvalues=total_patrol_time_converted)
     )
 
     patrol_time_grouped_widget = (
         merge_widget_views.validate()
         .partial(widgets=total_patrol_time_sv_widgets)
         .call(**params["patrol_time_grouped_widget"])
+    )
+
+    total_patrol_dist = (
+        dataframe_column_sum.validate()
+        .partial(**params["total_patrol_dist"])
+        .mapvalues(argnames=["df"], argvalues=split_patrol_traj_groups)
+    )
+
+    total_patrol_dist_converted = (
+        apply_arithmetic_operation.validate()
+        .partial(**params["total_patrol_dist_converted"])
+        .mapvalues(argnames=["a"], argvalues=total_patrol_dist)
+    )
+
+    total_patrol_dist_sv_widgets = (
+        create_single_value_widget_single_view.validate()
+        .partial(**params["total_patrol_dist_sv_widgets"])
+        .map(argnames=["view", "data"], argvalues=total_patrol_dist_converted)
+    )
+
+    patrol_dist_grouped_widget = (
+        merge_widget_views.validate()
+        .partial(widgets=total_patrol_dist_sv_widgets)
+        .call(**params["patrol_dist_grouped_widget"])
     )
 
     patrol_events_bar_chart = (
@@ -255,6 +279,7 @@ if __name__ == "__main__":
                 patrol_events_pie_chart_widget,
                 total_patrols_grouped_sv_widget,
                 patrol_time_grouped_widget,
+                patrol_dist_grouped_widget,
             ],
             groupers=groupers,
         )

--- a/examples/params/patrol_workflow_params.yaml
+++ b/examples/params/patrol_workflow_params.yaml
@@ -109,6 +109,22 @@ total_patrols_sv_widgets:
 # Parameters for 'Merge per group Total Patrols SV widgets into one Grouped Widget' using task `merge_widget_views`.
 total_patrols_grouped_sv_widget: {}
 
+# Parameters for 'Calculate Total Patrol Time Per Group' using task `dataframe_column_sum`.
+total_patrol_time:
+  column_name: "timespan_seconds"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Convert total patrol time units' using task `apply_arithmetic_operation`.
+total_patrol_time_converted:
+  b: 3600  # (float | int, FieldInfo(annotation=NoneType, required=True, description='The second number'))
+  operation: divide  # (typing.Literal['add', 'subtract', 'multiply', 'divide', 'floor_divide', 'modulo', 'power'], FieldInfo(annotation=NoneType, required=True, description='The arithmetic operation to apply'))
+
+# Parameters for 'Create Single Value Widgets for Total Patrol Time Per Group' using task `create_single_value_widget_single_view`.
+total_patrol_time_sv_widgets:
+  title: "Total Time"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+patrol_time_grouped_widget: {}
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis: "updated_at"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x axis.'))

--- a/examples/params/patrol_workflow_params.yaml
+++ b/examples/params/patrol_workflow_params.yaml
@@ -141,6 +141,17 @@ total_patrol_dist_sv_widgets:
 # Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
 patrol_dist_grouped_widget: {}
 
+# Parameters for 'Calculate Average Speed Per Group' using task `dataframe_column_mean`.
+avg_speed:
+  column_name: "speed_kmhr"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Avg Speed Per Group' using task `create_single_value_widget_single_view`.
+avg_speed_sv_widgets:
+  title: "Average Speed"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Avg Speed SV widgets' using task `merge_widget_views`.
+avg_speed_grouped_widget: {}
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis: "updated_at"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x axis.'))

--- a/examples/params/patrol_workflow_params.yaml
+++ b/examples/params/patrol_workflow_params.yaml
@@ -125,6 +125,22 @@ total_patrol_time_sv_widgets:
 # Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
 patrol_time_grouped_widget: {}
 
+# Parameters for 'Calculate Total Distance Per Group' using task `dataframe_column_sum`.
+total_patrol_dist:
+  column_name: "dist_meters"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Convert total patrol distance units' using task `apply_arithmetic_operation`.
+total_patrol_dist_converted:
+  b: 1000  # (float | int, FieldInfo(annotation=NoneType, required=True, description='The second number'))
+  operation: divide  # (typing.Literal['add', 'subtract', 'multiply', 'divide', 'floor_divide', 'modulo', 'power'], FieldInfo(annotation=NoneType, required=True, description='The arithmetic operation to apply'))
+
+# Parameters for 'Create Single Value Widgets for Total Distance Per Group' using task `create_single_value_widget_single_view`.
+total_patrol_dist_sv_widgets:
+  title: "Total Distance"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+patrol_dist_grouped_widget: {}
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis: "updated_at"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x axis.'))

--- a/examples/params/patrol_workflow_params.yaml
+++ b/examples/params/patrol_workflow_params.yaml
@@ -98,6 +98,17 @@ traj_pe_map_widgets_single_views:
 # Parameters for 'Merge EcoMap Widget Views' using task `merge_widget_views`.
 traj_pe_grouped_map_widget: {}
 
+# Parameters for 'Calculate Total Patrols Per Group' using task `dataframe_column_nunique`.
+total_patrols:
+  column_name: "extra__patrol_id"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Total Patrols Per Group' using task `create_single_value_widget_single_view`.
+total_patrols_sv_widgets:
+  title: "Total Patrols"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrols SV widgets into one Grouped Widget' using task `merge_widget_views`.
+total_patrols_grouped_sv_widget: {}
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis: "updated_at"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x axis.'))

--- a/examples/params/patrol_workflow_params.yaml
+++ b/examples/params/patrol_workflow_params.yaml
@@ -152,6 +152,17 @@ avg_speed_sv_widgets:
 # Parameters for 'Merge per group Avg Speed SV widgets' using task `merge_widget_views`.
 avg_speed_grouped_widget: {}
 
+# Parameters for 'Calculate Max Speed Per Group' using task `dataframe_column_max`.
+max_speed:
+  column_name: "speed_kmhr"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Max Speed Per Group' using task `create_single_value_widget_single_view`.
+max_speed_sv_widgets:
+  title: "Max Speed"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Max Speed SV widgets' using task `merge_widget_views`.
+max_speed_grouped_widget: {}
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis: "updated_at"  # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x axis.'))

--- a/examples/params/patrol_workflow_params_fillable.json
+++ b/examples/params/patrol_workflow_params_fillable.json
@@ -677,6 +677,658 @@
             "required": [],
             "type": "object"
         },
+        "Calculate Total Patrols Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string",
+                    "description": "Column to aggregate"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "type": "object"
+        },
+        "Create Single Value Widgets for Total Patrols Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "description": "The title of the widget"
+                }
+            },
+            "required": [
+                "title"
+            ],
+            "type": "object"
+        },
+        "Merge per group Total Patrols SV widgets": {
+            "$defs": {
+                "WidgetSingleView": {
+                    "properties": {
+                        "widget_type": {
+                            "enum": [
+                                "plot",
+                                "map",
+                                "text",
+                                "single_value"
+                            ],
+                            "title": "Widget Type",
+                            "type": "string"
+                        },
+                        "title": {
+                            "title": "Title",
+                            "type": "string"
+                        },
+                        "data": {
+                            "anyOf": [
+                                {
+                                    "format": "path",
+                                    "type": "string"
+                                },
+                                {
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "title": "Data"
+                        },
+                        "view": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxItems": 3,
+                                        "minItems": 3,
+                                        "prefixItems": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "const": "=",
+                                                "enum": [
+                                                    "="
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "title": "View"
+                        }
+                    },
+                    "required": [
+                        "widget_type",
+                        "title",
+                        "data"
+                    ],
+                    "title": "WidgetSingleView",
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "properties": {},
+            "required": [],
+            "type": "object"
+        },
+        "Calculate Total Patrol Time Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string",
+                    "description": "Column to aggregate"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "type": "object"
+        },
+        "Convert total patrol time units": {
+            "additionalProperties": false,
+            "properties": {
+                "b": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "B",
+                    "description": "The second number"
+                },
+                "operation": {
+                    "enum": [
+                        "add",
+                        "subtract",
+                        "multiply",
+                        "divide",
+                        "floor_divide",
+                        "modulo",
+                        "power"
+                    ],
+                    "title": "Operation",
+                    "type": "string",
+                    "description": "The arithmetic operation to apply"
+                }
+            },
+            "required": [
+                "b",
+                "operation"
+            ],
+            "type": "object"
+        },
+        "Create Single Value Widgets for Total Patrol Time Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "description": "The title of the widget"
+                }
+            },
+            "required": [
+                "title"
+            ],
+            "type": "object"
+        },
+        "Merge per group Total Patrol Time SV widgets": {
+            "$defs": {
+                "WidgetSingleView": {
+                    "properties": {
+                        "widget_type": {
+                            "enum": [
+                                "plot",
+                                "map",
+                                "text",
+                                "single_value"
+                            ],
+                            "title": "Widget Type",
+                            "type": "string"
+                        },
+                        "title": {
+                            "title": "Title",
+                            "type": "string"
+                        },
+                        "data": {
+                            "anyOf": [
+                                {
+                                    "format": "path",
+                                    "type": "string"
+                                },
+                                {
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "title": "Data"
+                        },
+                        "view": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxItems": 3,
+                                        "minItems": 3,
+                                        "prefixItems": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "const": "=",
+                                                "enum": [
+                                                    "="
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "title": "View"
+                        }
+                    },
+                    "required": [
+                        "widget_type",
+                        "title",
+                        "data"
+                    ],
+                    "title": "WidgetSingleView",
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "properties": {},
+            "required": [],
+            "type": "object"
+        },
+        "Calculate Total Distance Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string",
+                    "description": "Column to aggregate"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "type": "object"
+        },
+        "Convert total patrol distance units": {
+            "additionalProperties": false,
+            "properties": {
+                "b": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "B",
+                    "description": "The second number"
+                },
+                "operation": {
+                    "enum": [
+                        "add",
+                        "subtract",
+                        "multiply",
+                        "divide",
+                        "floor_divide",
+                        "modulo",
+                        "power"
+                    ],
+                    "title": "Operation",
+                    "type": "string",
+                    "description": "The arithmetic operation to apply"
+                }
+            },
+            "required": [
+                "b",
+                "operation"
+            ],
+            "type": "object"
+        },
+        "Create Single Value Widgets for Total Distance Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "description": "The title of the widget"
+                }
+            },
+            "required": [
+                "title"
+            ],
+            "type": "object"
+        },
+        "Merge per group Total Patrol Distance SV widgets": {
+            "$defs": {
+                "WidgetSingleView": {
+                    "properties": {
+                        "widget_type": {
+                            "enum": [
+                                "plot",
+                                "map",
+                                "text",
+                                "single_value"
+                            ],
+                            "title": "Widget Type",
+                            "type": "string"
+                        },
+                        "title": {
+                            "title": "Title",
+                            "type": "string"
+                        },
+                        "data": {
+                            "anyOf": [
+                                {
+                                    "format": "path",
+                                    "type": "string"
+                                },
+                                {
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "title": "Data"
+                        },
+                        "view": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxItems": 3,
+                                        "minItems": 3,
+                                        "prefixItems": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "const": "=",
+                                                "enum": [
+                                                    "="
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "title": "View"
+                        }
+                    },
+                    "required": [
+                        "widget_type",
+                        "title",
+                        "data"
+                    ],
+                    "title": "WidgetSingleView",
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "properties": {},
+            "required": [],
+            "type": "object"
+        },
+        "Calculate Average Speed Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string",
+                    "description": "Column to aggregate"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "type": "object"
+        },
+        "Create Single Value Widgets for Avg Speed Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "description": "The title of the widget"
+                }
+            },
+            "required": [
+                "title"
+            ],
+            "type": "object"
+        },
+        "Merge per group Avg Speed SV widgets": {
+            "$defs": {
+                "WidgetSingleView": {
+                    "properties": {
+                        "widget_type": {
+                            "enum": [
+                                "plot",
+                                "map",
+                                "text",
+                                "single_value"
+                            ],
+                            "title": "Widget Type",
+                            "type": "string"
+                        },
+                        "title": {
+                            "title": "Title",
+                            "type": "string"
+                        },
+                        "data": {
+                            "anyOf": [
+                                {
+                                    "format": "path",
+                                    "type": "string"
+                                },
+                                {
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "title": "Data"
+                        },
+                        "view": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxItems": 3,
+                                        "minItems": 3,
+                                        "prefixItems": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "const": "=",
+                                                "enum": [
+                                                    "="
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "title": "View"
+                        }
+                    },
+                    "required": [
+                        "widget_type",
+                        "title",
+                        "data"
+                    ],
+                    "title": "WidgetSingleView",
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "properties": {},
+            "required": [],
+            "type": "object"
+        },
+        "Calculate Max Speed Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string",
+                    "description": "Column to aggregate"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "type": "object"
+        },
+        "Create Single Value Widgets for Max Speed Per Group": {
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "description": "The title of the widget"
+                }
+            },
+            "required": [
+                "title"
+            ],
+            "type": "object"
+        },
+        "Merge per group Max Speed SV widgets": {
+            "$defs": {
+                "WidgetSingleView": {
+                    "properties": {
+                        "widget_type": {
+                            "enum": [
+                                "plot",
+                                "map",
+                                "text",
+                                "single_value"
+                            ],
+                            "title": "Widget Type",
+                            "type": "string"
+                        },
+                        "title": {
+                            "title": "Title",
+                            "type": "string"
+                        },
+                        "data": {
+                            "anyOf": [
+                                {
+                                    "format": "path",
+                                    "type": "string"
+                                },
+                                {
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "title": "Data"
+                        },
+                        "view": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "maxItems": 3,
+                                        "minItems": 3,
+                                        "prefixItems": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "const": "=",
+                                                "enum": [
+                                                    "="
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "title": "View"
+                        }
+                    },
+                    "required": [
+                        "widget_type",
+                        "title",
+                        "data"
+                    ],
+                    "title": "WidgetSingleView",
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "properties": {},
+            "required": [],
+            "type": "object"
+        },
         "Draw Time Series Bar Chart for Patrols Events": {
             "additionalProperties": false,
             "properties": {

--- a/examples/params/patrol_workflow_params_fillable.yaml
+++ b/examples/params/patrol_workflow_params_fillable.yaml
@@ -120,7 +120,7 @@ total_patrol_time_converted:
 total_patrol_time_sv_widgets:
   title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
 
-# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+# Parameters for 'Merge per group Total Patrol Time SV widgets' using task `merge_widget_views`.
 patrol_time_grouped_widget:
 
 # Parameters for 'Calculate Total Distance Per Group' using task `dataframe_column_sum`.
@@ -136,8 +136,19 @@ total_patrol_dist_converted:
 total_patrol_dist_sv_widgets:
   title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
 
-# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+# Parameters for 'Merge per group Total Patrol Distance SV widgets' using task `merge_widget_views`.
 patrol_dist_grouped_widget:
+
+# Parameters for 'Calculate Average Speed Per Group' using task `dataframe_column_mean`.
+avg_speed:
+  column_name:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Avg Speed Per Group' using task `create_single_value_widget_single_view`.
+avg_speed_sv_widgets:
+  title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Avg Speed SV widgets' using task `merge_widget_views`.
+avg_speed_grouped_widget:
 
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:

--- a/examples/params/patrol_workflow_params_fillable.yaml
+++ b/examples/params/patrol_workflow_params_fillable.yaml
@@ -123,6 +123,22 @@ total_patrol_time_sv_widgets:
 # Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
 patrol_time_grouped_widget:
 
+# Parameters for 'Calculate Total Distance Per Group' using task `dataframe_column_sum`.
+total_patrol_dist:
+  column_name:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Convert total patrol distance units' using task `apply_arithmetic_operation`.
+total_patrol_dist_converted:
+  b:   # (float | int, FieldInfo(annotation=NoneType, required=True, description='The second number'))
+  operation:   # (typing.Literal['add', 'subtract', 'multiply', 'divide', 'floor_divide', 'modulo', 'power'], FieldInfo(annotation=NoneType, required=True, description='The arithmetic operation to apply'))
+
+# Parameters for 'Create Single Value Widgets for Total Distance Per Group' using task `create_single_value_widget_single_view`.
+total_patrol_dist_sv_widgets:
+  title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+patrol_dist_grouped_widget:
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x/time axis.'))

--- a/examples/params/patrol_workflow_params_fillable.yaml
+++ b/examples/params/patrol_workflow_params_fillable.yaml
@@ -150,6 +150,17 @@ avg_speed_sv_widgets:
 # Parameters for 'Merge per group Avg Speed SV widgets' using task `merge_widget_views`.
 avg_speed_grouped_widget:
 
+# Parameters for 'Calculate Max Speed Per Group' using task `dataframe_column_max`.
+max_speed:
+  column_name:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Max Speed Per Group' using task `create_single_value_widget_single_view`.
+max_speed_sv_widgets:
+  title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Max Speed SV widgets' using task `merge_widget_views`.
+max_speed_grouped_widget:
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x/time axis.'))

--- a/examples/params/patrol_workflow_params_fillable.yaml
+++ b/examples/params/patrol_workflow_params_fillable.yaml
@@ -81,13 +81,13 @@ traj_patrol_events_ecomap:
   tile_layer:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='A named tile layer, ie OpenStreetMap.'))
   static:   # (<class 'bool'>, FieldInfo(annotation=NoneType, required=True, description='Set to true to disable map pan/zoom.'))
   title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The map title.'))
-  title_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Title.'))
-  scale_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Scale Bar.'))
-  north_arrow_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the North Arrow.'))
+  title_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Title.'))
+  scale_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Scale Bar.'))
+  north_arrow_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the North Arrow.'))
 
 # Parameters for 'Persist Patrols Ecomap as Text' using task `persist_text`.
 traj_pe_ecomap_html_urls:
-  filename:   # (str | None, FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
+  filename:   # (typing.Union[str, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
 
 # Parameters for 'Create Map Widgets for Patrol Events' using task `create_map_widget_single_view`.
 traj_pe_map_widgets_single_views:
@@ -96,6 +96,33 @@ traj_pe_map_widgets_single_views:
 # Parameters for 'Merge EcoMap Widget Views' using task `merge_widget_views`.
 traj_pe_grouped_map_widget:
 
+# Parameters for 'Calculate Total Patrols Per Group' using task `dataframe_column_nunique`.
+total_patrols:
+  column_name:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Create Single Value Widgets for Total Patrols Per Group' using task `create_single_value_widget_single_view`.
+total_patrols_sv_widgets:
+  title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrols SV widgets' using task `merge_widget_views`.
+total_patrols_grouped_sv_widget:
+
+# Parameters for 'Calculate Total Patrol Time Per Group' using task `dataframe_column_sum`.
+total_patrol_time:
+  column_name:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='Column to aggregate'))
+
+# Parameters for 'Convert total patrol time units' using task `apply_arithmetic_operation`.
+total_patrol_time_converted:
+  b:   # (float | int, FieldInfo(annotation=NoneType, required=True, description='The second number'))
+  operation:   # (typing.Literal['add', 'subtract', 'multiply', 'divide', 'floor_divide', 'modulo', 'power'], FieldInfo(annotation=NoneType, required=True, description='The arithmetic operation to apply'))
+
+# Parameters for 'Create Single Value Widgets for Total Patrol Time Per Group' using task `create_single_value_widget_single_view`.
+total_patrol_time_sv_widgets:
+  title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The title of the widget'))
+
+# Parameters for 'Merge per group Total Patrol Per Group SV widgets' using task `merge_widget_views`.
+patrol_time_grouped_widget:
+
 # Parameters for 'Draw Time Series Bar Chart for Patrols Events' using task `draw_time_series_bar_chart`.
 patrol_events_bar_chart:
   x_axis:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to plot in the x/time axis.'))
@@ -103,13 +130,13 @@ patrol_events_bar_chart:
   category:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The dataframe column to stack in the y axis.'))
   agg_function:   # (typing.Literal['count', 'mean', 'sum', 'min', 'max'], FieldInfo(annotation=NoneType, required=True, description='The aggregate function to apply to the group.'))
   time_interval:   # (typing.Literal['year', 'month', 'week', 'day', 'hour'], FieldInfo(annotation=NoneType, required=True, description='Sets the time interval of the x axis.'))
-  groupby_style_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Bar and applied to individual groups.'))
-  style_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Bar and applied to all groups.'))
-  layout_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Figure.'))
+  groupby_style_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Bar and applied to individual groups.'))
+  style_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Bar and applied to all groups.'))
+  layout_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Style arguments passed to plotly.graph_objects.Figure.'))
 
 # Parameters for 'Persist Patrols Bar Chart as Text' using task `persist_text`.
 patrol_events_bar_chart_html_url:
-  filename:   # (str | None, FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
+  filename:   # (typing.Union[str, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
 
 # Parameters for 'Create Plot Widget for Patrol Events' using task `create_plot_widget_single_view`.
 patrol_events_bar_chart_widget:
@@ -119,13 +146,13 @@ patrol_events_bar_chart_widget:
 # Parameters for 'Draw Pie Chart for Patrols Events' using task `draw_pie_chart`.
 patrol_events_pie_chart:
   value_column:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The name of the dataframe column to pull slice values from.'))
-  label_column:   # (str | None, FieldInfo(annotation=NoneType, required=True, description='The name of the dataframe column to label slices with, required if the data in value_column is numeric.'))
-  style_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional style kwargs passed to go.Pie().'))
-  layout_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional kwargs passed to plotly.go.Figure(layout).'))
+  label_column:   # (typing.Union[str, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='The name of the dataframe column to label slices with, required if the data in value_column is numeric.'))
+  style_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional style kwargs passed to go.Pie().'))
+  layout_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional kwargs passed to plotly.go.Figure(layout).'))
 
 # Parameters for 'Persist Patrols Pie Chart as Text' using task `persist_text`.
 patrol_events_pie_chart_html_url:
-  filename:   # (str | None, FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
+  filename:   # (typing.Union[str, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
 
 # Parameters for 'Create Plot Widget for Patrol Events' using task `create_plot_widget_single_view`.
 patrol_events_pie_chart_widget:
@@ -152,13 +179,13 @@ td_ecomap:
   tile_layer:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='A named tile layer, ie OpenStreetMap.'))
   static:   # (<class 'bool'>, FieldInfo(annotation=NoneType, required=True, description='Set to true to disable map pan/zoom.'))
   title:   # (<class 'str'>, FieldInfo(annotation=NoneType, required=True, description='The map title.'))
-  title_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Title.'))
-  scale_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Scale Bar.'))
-  north_arrow_kws:   # (dict | None, FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the North Arrow.'))
+  title_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Title.'))
+  scale_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the Scale Bar.'))
+  north_arrow_kws:   # (typing.Union[dict, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='Additional arguments for configuring the North Arrow.'))
 
 # Parameters for 'Persist Ecomap as Text' using task `persist_text`.
 td_ecomap_html_url:
-  filename:   # (str | None, FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
+  filename:   # (typing.Union[str, typing.Annotated[NoneType, SkipJsonSchema()]], FieldInfo(annotation=NoneType, required=True, description='            Optional filename to persist text to within the `root_path`.\n            If not provided, a filename will be generated based on a hash of the text content.\n            '))
 
 # Parameters for 'Create Time Density Map Widget' using task `create_map_widget_single_view`.
 td_map_widget:

--- a/tests/tasks/test_aggregate.py
+++ b/tests/tasks/test_aggregate.py
@@ -22,6 +22,12 @@ def test_sum():
     assert result == 6
 
 
+def test_nunique():
+    df = pd.DataFrame({"data": [1, 2, 3, 1]})
+    result = aggregate(df, "data", "nunique")
+    assert result == 3
+
+
 def test_invalid_function():
     df = pd.DataFrame({"data": [1, 2, 3]})
     with pytest.raises(ValueError):

--- a/tests/tasks/test_aggregate.py
+++ b/tests/tasks/test_aggregate.py
@@ -4,6 +4,8 @@ import pytest
 from ecoscope_workflows.tasks.analysis import (
     apply_arithmetic_operation,
     dataframe_column_mean,
+    dataframe_column_max,
+    dataframe_column_min,
     dataframe_column_nunique,
     dataframe_column_sum,
     dataframe_count,
@@ -26,6 +28,18 @@ def test_sum():
     df = pd.DataFrame({"data": [1, 2, 3]})
     result = dataframe_column_sum(df, "data")
     assert result == 6
+
+
+def test_max():
+    df = pd.DataFrame({"data": [1, 2, 3]})
+    result = dataframe_column_max(df, "data")
+    assert result == 3
+
+
+def test_min():
+    df = pd.DataFrame({"data": [1, 2, 3]})
+    result = dataframe_column_min(df, "data")
+    assert result == 1
 
 
 def test_nunique():

--- a/tests/tasks/test_aggregate.py
+++ b/tests/tasks/test_aggregate.py
@@ -7,19 +7,19 @@ from ecoscope_workflows.tasks.analysis import aggregate
 def test_count():
     df = pd.DataFrame({"data": [1, 2, 3]})
     result = aggregate(df, "data", "count")
-    pd.testing.assert_series_equal(result, pd.Series({"data_count": 3}))
+    assert result == 3
 
 
 def test_mean():
     df = pd.DataFrame({"data": [1, 2, 3]})
     result = aggregate(df, "data", "mean")
-    pd.testing.assert_series_equal(result, pd.Series({"data_mean": 2.0}))
+    assert result == 2.0
 
 
 def test_sum():
     df = pd.DataFrame({"data": [1, 2, 3]})
     result = aggregate(df, "data", "sum")
-    pd.testing.assert_series_equal(result, pd.Series({"data_sum": 6}))
+    assert result == 6
 
 
 def test_invalid_function():

--- a/tests/tasks/test_aggregate.py
+++ b/tests/tasks/test_aggregate.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import pytest
 
 from ecoscope_workflows.tasks.analysis import (
+    apply_arithmetic_operation,
     dataframe_column_mean,
     dataframe_column_nunique,
     dataframe_column_sum,
@@ -30,3 +32,20 @@ def test_nunique():
     df = pd.DataFrame({"data": [1, 2, 3, 1]})
     result = dataframe_column_nunique(df, "data")
     assert result == 3
+
+
+@pytest.mark.parametrize(
+    "a, b, operation, expected",
+    [
+        (1, 2, "add", 3),
+        (3, 2, "subtract", 1),
+        (2, 3, "multiply", 6),
+        (6, 3, "divide", 2),
+        (7, 3, "floor_divide", 2),
+        (7, 3, "modulo", 1),
+        (2, 3, "power", 8),
+    ],
+)
+def test_apply_arithmetic_operation(a, b, operation, expected):
+    result = apply_arithmetic_operation(a, b, operation)
+    assert result == expected

--- a/tests/tasks/test_aggregate.py
+++ b/tests/tasks/test_aggregate.py
@@ -1,34 +1,32 @@
 import pandas as pd
-import pytest
 
-from ecoscope_workflows.tasks.analysis import aggregate
+from ecoscope_workflows.tasks.analysis import (
+    dataframe_column_mean,
+    dataframe_column_nunique,
+    dataframe_column_sum,
+    dataframe_count,
+)
 
 
 def test_count():
     df = pd.DataFrame({"data": [1, 2, 3]})
-    result = aggregate(df, "data", "count")
+    result = dataframe_count(df)
     assert result == 3
 
 
 def test_mean():
     df = pd.DataFrame({"data": [1, 2, 3]})
-    result = aggregate(df, "data", "mean")
+    result = dataframe_column_mean(df, "data")
     assert result == 2.0
 
 
 def test_sum():
     df = pd.DataFrame({"data": [1, 2, 3]})
-    result = aggregate(df, "data", "sum")
+    result = dataframe_column_sum(df, "data")
     assert result == 6
 
 
 def test_nunique():
     df = pd.DataFrame({"data": [1, 2, 3, 1]})
-    result = aggregate(df, "data", "nunique")
+    result = dataframe_column_nunique(df, "data")
     assert result == 3
-
-
-def test_invalid_function():
-    df = pd.DataFrame({"data": [1, 2, 3]})
-    with pytest.raises(ValueError):
-        aggregate(df, "data", "invalid_function")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -110,6 +110,7 @@ assert_that_stdout = {
         lambda out: "widget_type='map', title='Time Density Map'" in out,
         lambda out: "widget_type='plot', title='Patrol Events Bar Chart'" in out,
         lambda out: "widget_type='plot', title='Patrol Events Pie Chart'" in out,
+        lambda out: "widget_type='single_value', title='Total Patrols'" in out,
     ],
     "mode-map.yaml": [
         lambda out: ".html" in out,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -112,6 +112,7 @@ assert_that_stdout = {
         lambda out: "widget_type='plot', title='Patrol Events Pie Chart'" in out,
         lambda out: "widget_type='single_value', title='Total Patrols'" in out,
         lambda out: "widget_type='single_value', title='Total Time'" in out,
+        lambda out: "widget_type='single_value', title='Total Distance'" in out,
     ],
     "mode-map.yaml": [
         lambda out: ".html" in out,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -111,6 +111,7 @@ assert_that_stdout = {
         lambda out: "widget_type='plot', title='Patrol Events Bar Chart'" in out,
         lambda out: "widget_type='plot', title='Patrol Events Pie Chart'" in out,
         lambda out: "widget_type='single_value', title='Total Patrols'" in out,
+        lambda out: "widget_type='single_value', title='Total Time'" in out,
     ],
     "mode-map.yaml": [
         lambda out: ".html" in out,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -113,6 +113,7 @@ assert_that_stdout = {
         lambda out: "widget_type='single_value', title='Total Patrols'" in out,
         lambda out: "widget_type='single_value', title='Total Time'" in out,
         lambda out: "widget_type='single_value', title='Total Distance'" in out,
+        lambda out: "widget_type='single_value', title='Average Speed'" in out,
     ],
     "mode-map.yaml": [
         lambda out: ".html" in out,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -114,6 +114,7 @@ assert_that_stdout = {
         lambda out: "widget_type='single_value', title='Total Time'" in out,
         lambda out: "widget_type='single_value', title='Total Distance'" in out,
         lambda out: "widget_type='single_value', title='Average Speed'" in out,
+        lambda out: "widget_type='single_value', title='Max Speed'" in out,
     ],
     "mode-map.yaml": [
         lambda out: ".html" in out,


### PR DESCRIPTION
closes #119 

Some notes for reviewers:

- I changed the single value tasks so that rather than providing the aggregation mode passed as a literal string, there is just a separate task per aggregation mode. This is for basically the same reason as discussed for widget factory tasks in #102; namely the spec doesn't currently support passing literal values (which I'd not been tracking when I reviewed the original single value widgets PR).
- I added an `apply_arithmetic_operation` task as a quick workaround to handle "unit conversion" but we may want to handle that in a more sophisticated way eventually. 🍺 Anyone care for a [pint](https://pint.readthedocs.io/en/stable/getting/overview.html)?
- Speaking of units: https://github.com/wildlife-dynamics/ecoscope-workflows/issues/177
