### PR TITLE
Add shell sript to (re)generate examples

### DIFF
--- a/generate_examples.sh
+++ b/generate_examples.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TEMPLATES=(
+    "jupytext"
+    "script-sequential"
+    "script-async"
+)
+
+# Generate dag and json/yaml params for each spec in "examples/compilation-specs/"
+for spec in examples/compilation-specs/*.yaml; do
+    specname=$(basename "${spec}" ".yaml")
+    for template in "${TEMPLATES[@]}"; do
+        ecoscope-workflows compile --spec "${spec}" --template "${template}.jinja2" --outpath "examples/dags/${specname//-/_}_dag.${template//-/_}.py"
+        done
+    ecoscope-workflows get-params --spec "${spec}" --format json --outpath "examples/params/${specname//-/_}_params_fillable.json"
+    ecoscope-workflows get-params --spec "${spec}" --format yaml --outpath "examples/params/${specname//-/_}_params_fillable.yaml"
+    done


### PR DESCRIPTION
Just a rough script that will regenerate anything in `/examples/compilation-specs` based on a list of templates.
~~Diff is large due to adjusting the naming convention of files~~  - realised that the naming convention was by design and updated script to suit.