### PR TITLE
Publish releases to prefix.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc"
+    branches:
+      - "main"
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: Build release
+        run: pixi run --manifest-path pixi.toml build-release
+      - name: Upload conda channel
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            /tmp/ecoscope-workflows/release/artifacts/
+            !/tmp/ecoscope-workflows/release/artifacts/bld
+            !/tmp/ecoscope-workflows/release/artifacts/src_cache
+          if-no-files-found: error
+          compression-level: 0
+
+  github-release:
+    needs:
+      - build
+    if: startsWith(github.ref, 'refs/tags/')
+
+    permissions:
+      contents: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download conda channel
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: /tmp/ecoscope-workflows/release/artifacts
+      - name: Log conda channel contents
+        run: ls -lR /tmp/ecoscope-workflows/release/artifacts
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --generate-notes
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}'
+          /tmp/ecoscope-workflows/release/artifacts/noarch/**
+          --repo '${{ github.repository }}'
+
+  publish-to-prefix:
+    needs:
+      - build
+    if: startsWith(github.ref, 'refs/tags/')
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download conda channel
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: /tmp/ecoscope-workflows/release/artifacts
+      - name: Log conda channel contents
+        run: ls -lR /tmp/ecoscope-workflows/release/artifacts
+
+      - uses: actions/checkout@v4
+      - name: Publish to prefix.dev
+        env:
+          PREFIX_API_KEY: ${{ secrets.PREFIX_API_KEY }}
+        run: |
+          chmod +x ./publish/push.sh
+          ./publish/push.sh


### PR DESCRIPTION
towards https://github.com/wildlife-dynamics/ecoscope-workflows/issues/271

Adds a github workflow for releasing `core` and `ext-ecoscope` packages to prefix.dev.

The github workflow is based on https://github.com/wildlife-dynamics/ecoscope/blob/master/.github/workflows/publish.yml

This PR (and subsequent prefix release) is required to unblock https://github.com/ecoscope-platform-workflows-releases/patrols/pull/1.